### PR TITLE
correct additionalWhere settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Pages
             pages = 1
             pages {
                 rootPageId = 1
-                additionalWhere = doktype!=6
+                additionalWhere = AND doktype!=6
             }
         }
     }
@@ -45,7 +45,7 @@ Plugin integration
             news {
                 active = 1
                 table = tx_news_domain_model_news
-                additionalWhere = pid!=0
+                additionalWhere = AND pid!=0
                 lastmod = tstamp
                 url = TEXT
                 url {


### PR DESCRIPTION
I corrected the additionalWhere clause in the README. It only works with an prefixed AND.