### PR TITLE
[FEATURE] Add option to end pagetrees by doktype

### DIFF
--- a/Classes/Domain/Repository/SitemapRepository.php
+++ b/Classes/Domain/Repository/SitemapRepository.php
@@ -208,10 +208,12 @@ class SitemapRepository
     {
         $pages = $this->getSubPages($rootPageId);
         foreach ($pages as $page) {
-            ArrayUtility::mergeRecursiveWithOverrule(
-                $pages,
-                $this->getSubPagesRecursive($page['uid'])
-            );
+            if (false === $this->isPageTreeLeaf($page)) {
+                ArrayUtility::mergeRecursiveWithOverrule(
+                    $pages,
+                    $this->getSubPagesRecursive($page['uid'])
+                );
+            }
         }
 
         return $pages;
@@ -267,6 +269,28 @@ class SitemapRepository
     {
         return GeneralUtility::inList(
             $this->pluginConfig['1']['urlEntries.']['pages.']['allowedDoktypes'],
+            $page['doktype']
+        );
+    }
+
+    /**
+     * Determines if the child page tree should not be fetched based on the current page.
+     * This is for example a "Backend User Section" or "Recycler" (configurable) or the
+     * page has "Stop Page Tree" activated (cannot be deactivated).
+     *
+     * A leaf is the last element in a tree.
+     *
+     * @param array $page
+     * @return bool
+     */
+    private function isPageTreeLeaf(array $page)
+    {
+        if ('1' === $page['php_tree_stop']) {
+            return true;
+        }
+
+        return GeneralUtility::inList(
+            $this->pluginConfig['1']['urlEntries.']['pages.']['stopPageTreeDoktypes'],
             $page['doktype']
         );
     }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -18,6 +18,7 @@ plugin.tx_sitemapgenerator {
 		pages {
 			rootPageId = 1
 			allowedDoktypes  = 1
+			stopPageTreeDoktypes = 6,199
 			hidePagesIfNotTranslated = 0
 		}
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -39,6 +39,7 @@ Installation
 -  You can add custom doktypes.
    Per default the sitemap.xml only lists normal pages with "doktype=1". The option takes a comma-separated list of numbers.
    plugin.tx\_sitemapgenerator.settings.urlEntries.pages.allowedDoktypes
+-  You can define doktypes which "end" the page tree, e.g. Backend User Section. Sub pages of pages of this doktype won't get fetched.
 -  sitemap is available on rootpage with pagetype 1449874941
    "/index.php?id=1&type=1449874941"
 
@@ -53,6 +54,7 @@ Pages
             pages {
                 rootPageId = 1
                 allowedDoktypes = 1
+                stopPageTreeDoktypes = 6,199
                 additionalWhere = doktype!=6
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
   ],
   "license": "GPL-2.0+",
   "require": {
-    "php": ">=5.5.0",
-    "typo3/cms": ">=6.2.20,<8.9.99",
-    "typo3/cms-core": ">=6.2.20,<8.9.99"
+    "php": ">=5.5.0,<7.2.0",
+    "typo3/cms": ">=6.2.20,<9.1.0",
+    "typo3/cms-core": ">=6.2.20,<9.1.0"
   },
   "require-dev": {
     "namelesscoder/typo3-repository-client": "^1.2.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -10,8 +10,8 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '6.2.7-8.99.99',
-            'php' => '5.5.0-0.0.0',
+            'typo3' => '6.2.20-9.0.99',
+            'php' => '5.5.0-7.1.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
This new option will end a pagetree per default when a backend user section or recycler is found. This patch also fixes some inconsistencies with the dependency version.
Also the page tree recursion will be skipped for a page with "Stop Page Tree" checked.