### PR TITLE
[BUGFIX] Fix for hideIfNotTranslated

### DIFF
--- a/Classes/Domain/Repository/SitemapRepository.php
+++ b/Classes/Domain/Repository/SitemapRepository.php
@@ -397,7 +397,8 @@ class SitemapRepository
         $language = GeneralUtility::_GET('L');
         if ($this->isRecordNotTranslated($recordConfig, $record, $language)) {
             $record = $this->pageRepository->getRecordOverlay($recordConfig['table'], $record, $language);
-            if (intval($record['l10n_parent']) !== 0) {
+            $transOrigPointerField = $GLOBALS['TCA'][$recordConfig['table']]['ctrl']['transOrigPointerField'];
+            if (intval($record[$transOrigPointerField]) !== 0) {
                 return $record;
             }
 


### PR DESCRIPTION
Use "transOrigPointerField" from $TCA to get the column which contains
the UID of the original record.

Not all tables store this value in the column "l10n_parent".